### PR TITLE
Allow custom JSON serialization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ builder.Services.AddSwaggerGen();
 builder.Services.ConfigureMessagingServices(builder.Configuration, true);
 ```
 
+## Custom JsonSerializerOptions
+
+You can customize JSON serialization in your application by injecting `JsonSerializerOptions` into the `ConfigureMessagingServices` method.
+
+### How to Use
+Pass your `JsonSerializerOptions` when setting up messaging services. If not provided, default settings are used.
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+var jsonOptions = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    WriteIndented = true,
+};
+
+builder.Services.ConfigureMessagingServices(
+    builder.Configuration,
+    useAzureCredentials: true,
+    jsonSerializerOptions: jsonOptions
+);
+```
+
 ## Publishing to EventHub
 
 To publish events to an EventHub you need an instance of `IEventHubPublisher`, this can be constructed via the `IEventHubPublisherFactory` which exposes the `Create(string eventHubName)` method

--- a/src/Atc.Azure.Messaging/EventHub/EventHubCredentialsPublisherFactory.cs
+++ b/src/Atc.Azure.Messaging/EventHub/EventHubCredentialsPublisherFactory.cs
@@ -1,3 +1,5 @@
+using Atc.Azure.Messaging.Serialization;
+
 namespace Atc.Azure.Messaging.EventHub;
 
 [SuppressMessage(
@@ -8,13 +10,16 @@ internal sealed class EventHubCredentialsPublisherFactory : IEventHubPublisherFa
 {
     private readonly string fullyQualifiedNamespace;
     private readonly DefaultAzureCredentialOptions credentialOptions;
+    private readonly IMessagePayloadSerializer messagePayloadSerializer;
 
     public EventHubCredentialsPublisherFactory(
         EventHubOptions options,
         EnvironmentOptions environmentOptions,
         ClientAuthorizationOptions clientCredentialOptions,
-        IAzureCredentialOptionsProvider credentialOptionsProvider)
+        IAzureCredentialOptionsProvider credentialOptionsProvider,
+        IMessagePayloadSerializer messagePayloadSerializer)
     {
+        this.messagePayloadSerializer = messagePayloadSerializer;
         this.fullyQualifiedNamespace = options.FullyQualifiedNamespace;
         this.credentialOptions = credentialOptionsProvider
             .GetAzureCredentialOptions(
@@ -24,8 +29,9 @@ internal sealed class EventHubCredentialsPublisherFactory : IEventHubPublisherFa
 
     public IEventHubPublisher Create(string eventHubName)
         => new EventHubPublisher(
-                new EventHubProducerClient(
-                    fullyQualifiedNamespace,
-                    eventHubName,
-                    new DefaultAzureCredential(credentialOptions)));
+            new EventHubProducerClient(
+                fullyQualifiedNamespace,
+                eventHubName,
+                new DefaultAzureCredential(credentialOptions)),
+            messagePayloadSerializer);
 }

--- a/src/Atc.Azure.Messaging/EventHub/EventHubPublisher.cs
+++ b/src/Atc.Azure.Messaging/EventHub/EventHubPublisher.cs
@@ -26,6 +26,17 @@ internal sealed class EventHubPublisher : IEventHubPublisher
             cancellationToken);
     }
 
+    public Task PublishAsync(
+        string message,
+        IDictionary<string, string>? messageProperties = null,
+        CancellationToken cancellationToken = default)
+    {
+        return PerformPublishAsync(
+            message,
+            messageProperties,
+            cancellationToken);
+    }
+
     private Task PerformPublishAsync(
         string messageBody,
         IDictionary<string, string>? messageProperties = null,

--- a/src/Atc.Azure.Messaging/EventHub/EventHubPublisher.cs
+++ b/src/Atc.Azure.Messaging/EventHub/EventHubPublisher.cs
@@ -1,12 +1,18 @@
+using Atc.Azure.Messaging.Serialization;
+
 namespace Atc.Azure.Messaging.EventHub;
 
 internal sealed class EventHubPublisher : IEventHubPublisher
 {
     private readonly EventHubProducerClient client;
+    private readonly IMessagePayloadSerializer messagePayloadSerializer;
 
-    public EventHubPublisher(EventHubProducerClient client)
+    public EventHubPublisher(
+        EventHubProducerClient client,
+        IMessagePayloadSerializer messagePayloadSerializer)
     {
         this.client = client;
+        this.messagePayloadSerializer = messagePayloadSerializer;
     }
 
     public Task PublishAsync(
@@ -15,7 +21,7 @@ internal sealed class EventHubPublisher : IEventHubPublisher
         CancellationToken cancellationToken = default)
     {
         return PerformPublishAsync(
-            JsonSerializer.Serialize(message),
+            messagePayloadSerializer.Serialize(message),
             messageProperties,
             cancellationToken);
     }
@@ -39,10 +45,7 @@ internal sealed class EventHubPublisher : IEventHubPublisher
         }
 
         return client.SendAsync(
-            new[]
-            {
-                eventData,
-            },
+            new[] { eventData, },
             cancellationToken);
     }
 

--- a/src/Atc.Azure.Messaging/EventHub/EventHubPublisherFactory.cs
+++ b/src/Atc.Azure.Messaging/EventHub/EventHubPublisherFactory.cs
@@ -1,3 +1,5 @@
+using Atc.Azure.Messaging.Serialization;
+
 namespace Atc.Azure.Messaging.EventHub;
 
 [SuppressMessage(
@@ -7,15 +9,20 @@ namespace Atc.Azure.Messaging.EventHub;
 internal sealed class EventHubPublisherFactory : IEventHubPublisherFactory
 {
     private readonly string connectionString;
+    private readonly IMessagePayloadSerializer messagePayloadSerializer;
 
-    public EventHubPublisherFactory(EventHubOptions options)
+    public EventHubPublisherFactory(
+        EventHubOptions options,
+        IMessagePayloadSerializer messagePayloadSerializer)
     {
-        this.connectionString = options.ConnectionString;
+        this.messagePayloadSerializer = messagePayloadSerializer;
+        connectionString = options.ConnectionString;
     }
 
     public IEventHubPublisher Create(string eventHubName)
         => new EventHubPublisher(
             new EventHubProducerClient(
                 connectionString,
-                eventHubName));
+                eventHubName),
+            messagePayloadSerializer);
 }

--- a/src/Atc.Azure.Messaging/EventHub/IEventHubPublisher.cs
+++ b/src/Atc.Azure.Messaging/EventHub/IEventHubPublisher.cs
@@ -12,4 +12,9 @@ public interface IEventHubPublisher : IAsyncDisposable
         object message,
         IDictionary<string, string>? messageProperties = null,
         CancellationToken cancellationToken = default);
+
+    Task PublishAsync(
+        string message,
+        IDictionary<string, string>? messageProperties = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Atc.Azure.Messaging/Serialization/IMessagePayloadSerializer.cs
+++ b/src/Atc.Azure.Messaging/Serialization/IMessagePayloadSerializer.cs
@@ -1,0 +1,8 @@
+namespace Atc.Azure.Messaging.Serialization;
+
+public interface IMessagePayloadSerializer
+{
+    string Serialize<T>(T value);
+
+    T? Deserialize<T>(string json);
+}

--- a/src/Atc.Azure.Messaging/Serialization/IMessagePayloadSerializer.cs
+++ b/src/Atc.Azure.Messaging/Serialization/IMessagePayloadSerializer.cs
@@ -3,6 +3,4 @@ namespace Atc.Azure.Messaging.Serialization;
 public interface IMessagePayloadSerializer
 {
     string Serialize<T>(T value);
-
-    T? Deserialize<T>(string json);
 }

--- a/src/Atc.Azure.Messaging/Serialization/MessagePayloadSerializer.cs
+++ b/src/Atc.Azure.Messaging/Serialization/MessagePayloadSerializer.cs
@@ -1,0 +1,17 @@
+namespace Atc.Azure.Messaging.Serialization;
+
+public class MessagePayloadSerializer : IMessagePayloadSerializer
+{
+    private readonly JsonSerializerOptions options;
+
+    public MessagePayloadSerializer(JsonSerializerOptions options)
+    {
+        this.options = options;
+    }
+
+    public string Serialize<T>(T value)
+        => JsonSerializer.Serialize(value, options);
+
+    public T? Deserialize<T>(string json)
+        => JsonSerializer.Deserialize<T>(json, options);
+}

--- a/src/Atc.Azure.Messaging/Serialization/MessagePayloadSerializer.cs
+++ b/src/Atc.Azure.Messaging/Serialization/MessagePayloadSerializer.cs
@@ -11,7 +11,4 @@ public class MessagePayloadSerializer : IMessagePayloadSerializer
 
     public string Serialize<T>(T value)
         => JsonSerializer.Serialize(value, options);
-
-    public T? Deserialize<T>(string json)
-        => JsonSerializer.Deserialize<T>(json, options);
 }

--- a/src/Atc.Azure.Messaging/ServiceBus/IServiceBusPublisher.cs
+++ b/src/Atc.Azure.Messaging/ServiceBus/IServiceBusPublisher.cs
@@ -24,6 +24,24 @@ public interface IServiceBusPublisher
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Publishes a message.
+    /// </summary>
+    /// <param name="topicOrQueue">The topic or queue name.</param>
+    /// <param name="message">The message to be published, in a serialized format.</param>
+    /// <param name="sessionId">Optional id for appending the message to a known session. If not set, then defaults to a new session.</param>
+    /// <param name="properties">Optional custom metadata about the message.</param>
+    /// <param name="timeToLive">Optional <see cref="TimeSpan"/> for message to be consumed. If not set, then defaults to the value specified on queue or topic.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task PublishAsync(
+        string topicOrQueue,
+        string message,
+        string? sessionId = null,
+        IDictionary<string, string>? properties = null,
+        TimeSpan? timeToLive = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Publishes multiple messages in batches. The list of messages will be split in multiple batches if the messages exceeds a single batch size.
     /// </summary>
     /// <param name="topicOrQueue">The topic or queue name.</param>

--- a/src/Atc.Azure.Messaging/ServiceBus/ServiceBusPublisher.cs
+++ b/src/Atc.Azure.Messaging/ServiceBus/ServiceBusPublisher.cs
@@ -34,6 +34,25 @@ internal sealed class ServiceBusPublisher : IServiceBusPublisher
                 cancellationToken);
     }
 
+    public Task PublishAsync(
+        string topicOrQueue,
+        string message,
+        string? sessionId = null,
+        IDictionary<string, string>? properties = null,
+        TimeSpan? timeToLive = null,
+        CancellationToken cancellationToken = default)
+    {
+        return clientProvider
+            .GetSender(topicOrQueue)
+            .SendMessageAsync(
+                CreateServiceBusMessage(
+                    sessionId,
+                    message,
+                    properties,
+                    timeToLive),
+                cancellationToken);
+    }
+
     public async Task PublishAsync(
         string topicOrQueue,
         IReadOnlyCollection<object> messages,

--- a/src/Atc.Azure.Messaging/ServiceCollectionExtensions.cs
+++ b/src/Atc.Azure.Messaging/ServiceCollectionExtensions.cs
@@ -26,11 +26,20 @@ public static class ServiceCollectionExtensions
     /// Parameter is only considered if <paramref name="useAzureCredentials"/> is set to true.
     /// </para>
     /// </param>
+    /// <param name="jsonSerializerOptions">
+    /// Optional <see cref="JsonSerializerOptions"/> to customize the serialization settings
+    /// used by messaging components for serializing and deserializing message payloads.
+    /// <para>
+    /// Provides a way to specify custom serialization behavior.
+    /// When not provided, the default serialization settings of <see cref="System.Text.Json.JsonSerializer"/> are used.
+    /// </para>
+    /// </param>
     public static void ConfigureMessagingServices(
         this IServiceCollection services,
         IConfiguration configuration,
         bool useAzureCredentials = false,
-        IAzureCredentialOptionsProvider? credentialOptionsProvider = null)
+        IAzureCredentialOptionsProvider? credentialOptionsProvider = null,
+        JsonSerializerOptions? jsonSerializerOptions = null)
     {
         services.AddOptions<EventHubOptions>(configuration);
         services.AddOptions<ServiceBusOptions>(configuration);
@@ -51,6 +60,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IServiceBusClientFactory, ServiceBusClientFactory>();
         services.AddSingleton<IServiceBusSenderProvider, ServiceBusSenderProvider>();
         services.AddSingleton<IServiceBusPublisher, ServiceBusPublisher>();
+
+        services.AddSingleton(jsonSerializerOptions ?? new JsonSerializerOptions());
     }
 
     private static T AddOptions<T>(

--- a/src/Atc.Azure.Messaging/ServiceCollectionExtensions.cs
+++ b/src/Atc.Azure.Messaging/ServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Atc.Azure.Messaging.Serialization;
+
 namespace Microsoft.Extensions.DependencyInjection;
 
 [ExcludeFromCodeCoverage]
@@ -61,6 +63,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IServiceBusSenderProvider, ServiceBusSenderProvider>();
         services.AddSingleton<IServiceBusPublisher, ServiceBusPublisher>();
 
+        services.AddSingleton<IMessagePayloadSerializer, MessagePayloadSerializer>();
         services.AddSingleton(jsonSerializerOptions ?? new JsonSerializerOptions());
     }
 

--- a/src/Atc.Azure.Messaging/ServiceCollectionExtensions.cs
+++ b/src/Atc.Azure.Messaging/ServiceCollectionExtensions.cs
@@ -63,8 +63,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IServiceBusSenderProvider, ServiceBusSenderProvider>();
         services.AddSingleton<IServiceBusPublisher, ServiceBusPublisher>();
 
-        services.AddSingleton<IMessagePayloadSerializer, MessagePayloadSerializer>();
-        services.AddSingleton(jsonSerializerOptions ?? new JsonSerializerOptions());
+        services.AddSingleton<IMessagePayloadSerializer>(
+            new MessagePayloadSerializer(
+                jsonSerializerOptions ?? new JsonSerializerOptions()));
     }
 
     private static T AddOptions<T>(

--- a/test/Atc.Azure.Messaging.Tests/EventHub/EventHubCredentialsPublisherFactoryTests.cs
+++ b/test/Atc.Azure.Messaging.Tests/EventHub/EventHubCredentialsPublisherFactoryTests.cs
@@ -1,3 +1,5 @@
+using Atc.Azure.Messaging.Serialization;
+
 namespace Atc.Azure.Messaging.Tests.EventHub;
 
 public class EventHubCredentialsPublisherFactoryTests
@@ -7,6 +9,7 @@ public class EventHubCredentialsPublisherFactoryTests
     [Theory, AutoNSubstituteData]
     public void Create_Returns_NotNull(
         [Frozen] IAzureCredentialOptionsProvider credentialOptionsProvider,
+        IMessagePayloadSerializer messagePayloadSerializer,
         EnvironmentOptions environmentOptions,
         ClientAuthorizationOptions authorizationOptions,
         string eventHubName)
@@ -14,7 +17,8 @@ public class EventHubCredentialsPublisherFactoryTests
             new EventHubOptions { FullyQualifiedNamespace = FullyQualifiedNamespace },
             environmentOptions,
             authorizationOptions,
-            credentialOptionsProvider)
+            credentialOptionsProvider,
+            messagePayloadSerializer)
         .Create(eventHubName)
         .Should()
         .NotBeNull();
@@ -22,6 +26,7 @@ public class EventHubCredentialsPublisherFactoryTests
     [Theory, AutoNSubstituteData]
     public void Create_Returns_IEventHubPublisher(
         [Frozen] IAzureCredentialOptionsProvider credentialOptionsProvider,
+        IMessagePayloadSerializer messagePayloadSerializer,
         EnvironmentOptions environmentOptions,
         ClientAuthorizationOptions authorizationOptions,
         string eventHubName)
@@ -29,7 +34,8 @@ public class EventHubCredentialsPublisherFactoryTests
             new EventHubOptions { FullyQualifiedNamespace = FullyQualifiedNamespace },
             environmentOptions,
             authorizationOptions,
-            credentialOptionsProvider)
+            credentialOptionsProvider,
+            messagePayloadSerializer)
         .Create(eventHubName)
         .Should()
         .BeAssignableTo<IEventHubPublisher>();
@@ -37,6 +43,7 @@ public class EventHubCredentialsPublisherFactoryTests
     [Theory, AutoNSubstituteData]
     public void Constructor_Calls_AzureCredentialsOptionsProvider(
         [Frozen] IAzureCredentialOptionsProvider credentialOptionsProvider,
+        IMessagePayloadSerializer messagePayloadSerializer,
         EventHubOptions eventHubOptions,
         EnvironmentOptions environmentOptions,
         ClientAuthorizationOptions authorizationOptions)
@@ -45,7 +52,8 @@ public class EventHubCredentialsPublisherFactoryTests
             eventHubOptions,
             environmentOptions,
             authorizationOptions,
-            credentialOptionsProvider);
+            credentialOptionsProvider,
+            messagePayloadSerializer);
 
         credentialOptionsProvider
             .Received(1)

--- a/test/Atc.Azure.Messaging.Tests/EventHub/EventHubPublisherFactoryTests.cs
+++ b/test/Atc.Azure.Messaging.Tests/EventHub/EventHubPublisherFactoryTests.cs
@@ -1,3 +1,5 @@
+using Atc.Azure.Messaging.Serialization;
+
 namespace Atc.Azure.Messaging.Tests.EventHub;
 
 public class EventHubPublisherFactoryTests
@@ -7,15 +9,23 @@ public class EventHubPublisherFactoryTests
         $"Endpoint={Endpoint};SharedAccessKeyName=<KeyName>;SharedAccessKey=<KeyValue>;";
 
     [Theory, AutoNSubstituteData]
-    public void Create_Returns_IEventHubPublisher(string eventHubName)
-        => new EventHubPublisherFactory(new EventHubOptions { ConnectionString = ConnectionString })
+    public void Create_Returns_IEventHubPublisher(
+        IMessagePayloadSerializer messagePayloadSerializer,
+        string eventHubName)
+        => new EventHubPublisherFactory(
+                new EventHubOptions { ConnectionString = ConnectionString },
+                messagePayloadSerializer)
             .Create(eventHubName)
             .Should()
             .BeAssignableTo<IEventHubPublisher>();
 
     [Theory, AutoNSubstituteData]
-    public void Create_Returns_NotNull(string eventHubName)
-        => new EventHubPublisherFactory(new EventHubOptions { ConnectionString = ConnectionString })
+    public void Create_Returns_NotNull(
+        IMessagePayloadSerializer messagePayloadSerializer,
+        string eventHubName)
+        => new EventHubPublisherFactory(
+                new EventHubOptions { ConnectionString = ConnectionString },
+                messagePayloadSerializer)
             .Create(eventHubName)
             .Should()
             .NotBeNull();

--- a/test/Atc.Azure.Messaging.Tests/EventHub/EventHubPublisherTests.cs
+++ b/test/Atc.Azure.Messaging.Tests/EventHub/EventHubPublisherTests.cs
@@ -1,3 +1,5 @@
+using Atc.Azure.Messaging.Serialization;
+
 namespace Atc.Azure.Messaging.Tests.EventHub;
 
 public class EventHubPublisherTests
@@ -25,11 +27,15 @@ public class EventHubPublisherTests
     [Theory, AutoNSubstituteData]
     internal async Task PublishAsync_Calls_Client_With_Correct_MessageBody(
         [Frozen, Substitute] EventHubProducerClient client,
+        [Frozen] IMessagePayloadSerializer serializer,
         EventHubPublisher sut,
-        object messageBody,
+        string messageBody,
         IDictionary<string, string> properties,
         CancellationToken cancellationToken)
     {
+        serializer
+            .Serialize<object>(default!)
+            .ReturnsForAnyArgs(messageBody);
         await sut.PublishAsync(
             messageBody,
             properties,
@@ -43,7 +49,7 @@ public class EventHubPublisherTests
             .Should()
             .BeEquivalentTo(
                 Encoding.UTF8.GetBytes(
-                    JsonSerializer.Serialize(messageBody)));
+                    messageBody));
     }
 
     [Theory, AutoNSubstituteData]


### PR DESCRIPTION
This PR introduces the option to specify their own JSON serialization options when configuring the SDK.
